### PR TITLE
Harden MITM server defaults and redact sensitive headers

### DIFF
--- a/mitmserver/README.md
+++ b/mitmserver/README.md
@@ -24,7 +24,20 @@ The server is a simple Node.js application that uses the `http-proxy` library. I
     ```bash
     npm start
     ```
-    The server will start listening on port 8080.
+    By default, the server listens on `127.0.0.1:8080` and forwards traffic to `http://localhost:3000`.
+
+2.  (Optional) Configure runtime settings with environment variables:
+    - `TARGET_URL` (default: `http://localhost:3000`)
+    - `HOST` (default: `127.0.0.1`)
+    - `PORT` (default: `8080`)
+
+    PowerShell example:
+    ```powershell
+    $env:TARGET_URL = "https://real.antigravity.backend.com"
+    $env:HOST = "127.0.0.1"
+    $env:PORT = "8080"
+    npm start
+    ```
 
 ## Configuring the Antigravity App
 
@@ -55,11 +68,6 @@ If you cannot directly configure the Antigravity application to use a proxy, you
 
 **Note:** Remember to disable the system-wide proxy settings when you are done testing, as it will affect all your internet traffic.
 
-**Important:** You will also need to update the `target` URL in `server.js` to point to the real Antigravity backend. The current placeholder is `http://localhost:3000`.
+**Important:** Set `TARGET_URL` to the real Antigravity backend before using this proxy with the official app.
 
-```javascript
-// server.js
-proxy.web(req, res, { target: 'https://real.antigravity.backend.com' }); // Change this URL
-```
-
-Once configured, you will see the requests and responses from the Antigravity app logged in your console.
+Once configured, you will see requests and responses logged in the console. Sensitive headers such as `Authorization` and `Cookie` are redacted.

--- a/mitmserver/server.js
+++ b/mitmserver/server.js
@@ -1,5 +1,56 @@
 const http = require('http');
+const { URL } = require('url');
 const httpProxy = require('http-proxy');
+
+const DEFAULT_TARGET_URL = 'http://localhost:3000';
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 8080;
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+  'set-cookie',
+  'x-api-key',
+]);
+
+function parsePort(rawPort) {
+  const parsedPort = Number.parseInt(rawPort, 10);
+  if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65535) {
+    throw new Error(`Invalid PORT value: "${rawPort}". Expected an integer between 1 and 65535.`);
+  }
+  return parsedPort;
+}
+
+function resolveTargetUrl(rawTargetUrl) {
+  let parsedTarget;
+  try {
+    parsedTarget = new URL(rawTargetUrl);
+  } catch (error) {
+    throw new Error(`Invalid TARGET_URL value: "${rawTargetUrl}".`);
+  }
+
+  if (!['http:', 'https:'].includes(parsedTarget.protocol)) {
+    throw new Error(
+      `Invalid TARGET_URL protocol "${parsedTarget.protocol}". Expected http: or https:.`
+    );
+  }
+
+  return parsedTarget.toString();
+}
+
+function redactHeaders(headers) {
+  const safeHeaders = {};
+
+  for (const [name, value] of Object.entries(headers)) {
+    safeHeaders[name] = SENSITIVE_HEADERS.has(name.toLowerCase()) ? '[redacted]' : value;
+  }
+
+  return safeHeaders;
+}
+
+const targetUrl = resolveTargetUrl(process.env.TARGET_URL || DEFAULT_TARGET_URL);
+const host = process.env.HOST || DEFAULT_HOST;
+const port = parsePort(process.env.PORT || String(DEFAULT_PORT));
 
 const proxy = httpProxy.createProxyServer({});
 
@@ -7,22 +58,41 @@ const server = http.createServer((req, res) => {
   console.log('Request received:');
   console.log('  Method:', req.method);
   console.log('  URL:', req.url);
-  console.log('  Headers:', req.headers);
+  console.log('  Headers:', redactHeaders(req.headers));
 
-  proxy.web(req, res, { target: 'http://localhost:3000' }, (e) => {
-    console.error('Proxy error:', e);
-    res.writeHead(502);
-    res.end('There was an error proxying the request.');
-  });
+  proxy.web(req, res, { target: targetUrl });
 });
 
 proxy.on('proxyRes', (proxyRes, req, res) => {
   console.log('Response received:');
   console.log('  Status:', proxyRes.statusCode);
-  console.log('  Headers:', proxyRes.headers);
+  console.log('  Headers:', redactHeaders(proxyRes.headers));
 });
 
-const PORT = 8080;
-server.listen(PORT, () => {
-  console.log(`MITM Proxy server listening on port ${PORT}`);
+proxy.on('error', (error, req, res) => {
+  console.error('Proxy error:', error.message);
+
+  if (res && !res.headersSent) {
+    res.writeHead(502);
+  }
+
+  if (res && !res.writableEnded) {
+    res.end('There was an error proxying the request.');
+  }
+});
+
+server.on('clientError', (error, socket) => {
+  console.error('Client error:', error.message);
+  if (socket.writable) {
+    socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
+  }
+});
+
+server.on('error', (error) => {
+  console.error('Server error:', error.message);
+});
+
+server.listen(port, host, () => {
+  console.log(`MITM Proxy server listening on http://${host}:${port}`);
+  console.log(`Forwarding traffic to ${targetUrl}`);
 });


### PR DESCRIPTION
## Summary
- bind MITM server to localhost by default (127.0.0.1) instead of all interfaces
- add env-driven runtime config: TARGET_URL, HOST, PORT with validation
- redact sensitive request/response headers in logs (e.g. Authorization, Cookie, X-Api-Key)
- improve proxy/server error handling without changing core proxy behavior
- update mitmserver/README.md with env-based configuration instructions

## Why
The previous defaults were convenient for local tests but risky when reused elsewhere: credentials could be printed in logs and service exposure was broader than necessary.

## Verification
- 
pm ci
- 
ode --check server.js
- live request through http://127.0.0.1:8080/... confirms startup and redaction behavior
- 
pm audit --omit=dev (0 vulnerabilities)

## Notes
- default TARGET_URL remains http://localhost:3000 for local workflow compatibility
- deprecation warning seen at runtime comes from http-proxy internals and is unchanged in this patch