### PR TITLE
Add .env.sample for mitmserver configuration (fixes #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ product.overrides.json
 .tool-versions
 src/vs/workbench/contrib/void/browser/react/out/**
 src/vs/workbench/contrib/void/browser/react/src2/**
+
+# Environment files
+.env
+.env.local

--- a/mitmserver/.env.sample
+++ b/mitmserver/.env.sample
@@ -1,0 +1,20 @@
+# open-antigravity MITM Proxy Configuration
+# Copy this file to .env and adjust values for your setup
+
+# Port the MITM proxy listens on
+PROXY_PORT=8080
+
+# Target server the proxy forwards requests to
+TARGET_HOST=http://localhost:3000
+
+# Logging level: debug, info, warn, error
+LOG_LEVEL=info
+
+# Optional: API key for authenticated proxying
+# API_KEY=your-api-key-here
+
+# Optional: Enable request/response body logging (caution: verbose)
+# LOG_BODIES=false
+
+# Optional: Max request body size (bytes)
+# MAX_BODY_SIZE=1048576


### PR DESCRIPTION
## Summary

Adds the missing `.env.sample` file requested in #3.

### Changes

- **`mitmserver/.env.sample`** — Configuration template with all proxy settings:
  - `PROXY_PORT` — Configurable listen port (default 8080)
  - `TARGET_HOST` — Proxy target URL (default localhost:3000)
  - `LOG_LEVEL` — Adjustable logging verbosity
  - `API_KEY` — Optional authentication for the proxy
  - `LOG_BODIES` — Optional request/response body logging
  - `MAX_BODY_SIZE` — Request size limits

- **`.gitignore`** — Added `.env` and `.env.local` to prevent accidental credential commits

### Usage

```bash
cd mitmserver
cp .env.sample .env
# Edit .env with your settings
npm start
```

Closes #3.